### PR TITLE
Issue 3 exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, `virtualb` provides these commands:
 |---|---|---|
 | `activate` | activate the specified virtualenv | `vb activate <virtualenv>` |
 |`deactivate`| deactivate the currently activated virtualenv.|`vb deactivate`|
-|`exec`|execute a command in the specified virtualenv|`vb exec <virtualenv> <command>`|
+|`exec`|execute a command in the specified virtualenv|`vb exec [-e env] <command>`|
 |`freeze`|list installed packages in currently activated or specified virtualenv| `vb freeze` or `vb freeze <virtualenv>`|
 |`help`|provide help for the given command|`vb help <command>`|
 |`ls`|list all virtualenvs by name|`vb ls`|

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A bash wrapper around Python's `virtualenv` tool. Inspired by [virtualz](https://github.com/aperezdc/virtualz), it aims to pull all virtualenv management into one command, with explicit and easy to remember subcommands.
 
+### Quick install
+
+```bash
+git clone https://github.com/tomplex/virtualb.git ~/.bash_plugins/virtualb
+echo "source $HOME/.bash_plugins/virtualb/virtualb.plugin.bash" >> ~/.bashrc
+```
+
 ### Usage
 
 `virtualb` provides the `vb` command, which groups together some useful virtualenv management tasks:
@@ -37,6 +44,7 @@ Currently, `virtualb` provides these commands:
 |---|---|---|
 | `activate` | activate the specified virtualenv | `vb activate <virtualenv>` |
 |`deactivate`| deactivate the currently activated virtualenv.|`vb deactivate`|
+|`exec`|execute a command in the specified virtualenv|`vb exec <virtualenv> <command>`
 |`freeze`|list installed packages in currently activated or specified virtualenv| `vb freeze` or `vb freeze <virtualenv>`|
 |`help`|provide help for the given command|`vb help <command>`|
 |`ls`|list all virtualenvs by name|`vb ls`|

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, `virtualb` provides these commands:
 |---|---|---|
 | `activate` | activate the specified virtualenv | `vb activate <virtualenv>` |
 |`deactivate`| deactivate the currently activated virtualenv.|`vb deactivate`|
-|`exec`|execute a command in the specified virtualenv|`vb exec <virtualenv> <command>`
+|`exec`|execute a command in the specified virtualenv|`vb exec <virtualenv> <command>`|
 |`freeze`|list installed packages in currently activated or specified virtualenv| `vb freeze` or `vb freeze <virtualenv>`|
 |`help`|provide help for the given command|`vb help <command>`|
 |`ls`|list all virtualenvs by name|`vb ls`|

--- a/docs/cmd_exec
+++ b/docs/cmd_exec
@@ -1,0 +1,11 @@
+Run a command in the specified environment.
+
+Usage:
+    vb exec [env] [command]
+    vb exec [command]
+
+If a virtualenv is active and none is specified,
+the currently active virtualenv will be used.
+A specified environment will override the currently
+active one.
+

--- a/docs/cmd_exec
+++ b/docs/cmd_exec
@@ -1,11 +1,21 @@
-Run a command in the specified environment.
+Pass a command to the specified or currently active
+environment. Equivalent to running `python <command>`
 
 Usage:
-    vb exec [env] [command]
-    vb exec [command]
+    vb exec [-e/--env virtualenv] <command>
+
 
 If a virtualenv is active and none is specified,
-the currently active virtualenv will be used.
-A specified environment will override the currently
+the currently active virtualenv will be used. A
+specified environment will override the currently
 active one.
+
+Use proper quoting within the command you're passing
+to the Python executable, but don't worry about wrapping
+the command itself in quotes; i.e.
+
+echo '{"hello":"world"}' | vb exec -e my_env -c "import sys, json; j = json.load(sys.stdin); print(j['hello'])"
+
+Everything after the -e my_env will be passed to the Python
+executable with quoting preserved.
 

--- a/virtualb.plugin.bash
+++ b/virtualb.plugin.bash
@@ -93,7 +93,7 @@ __virtualb_activate () {
 
     [[ ! -d $virtualenv_path ]] && echo "The virtualenv $virtualenv_name does not exist." 1>&2 && return 1
 
-    [[ -z ${VIRTUAL_ENV+x} ]] || __virtualb_deactivate
+    __virtualenv_currently_active && __virtualb_deactivate
 
     VIRTUAL_ENV_NAME=$virtualenv_name
     VIRTUAL_ENV=$virtualenv_path
@@ -103,7 +103,7 @@ __virtualb_activate () {
 
 
 __virtualb_deactivate () {
-    [[ -z ${VIRTUAL_ENV+x} ]] && echo "No virtualenv is active." 1>&2 && return 1
+    ! __virtualenv_currently_active && echo "No virtualenv is active." 1>&2 && return 1
 
     typeset -f "deactivate" > /dev/null && deactivate
     unset VIRTUAL_ENV VIRTUAL_ENV_NAME
@@ -137,14 +137,14 @@ __virtualb_rm () {
 
 
 __virtualb_which () {
-    [[ -z ${VIRTUAL_ENV+x} ]] && echo "No virtualenv is active." && return 0
+    ! __virtualenv_currently_active && echo "No virtualenv is active." && return 0
 
     echo $VIRTUAL_ENV_NAME
 }
 
 
 __virtualb_freeze () {
-    [[ -z ${VIRTUAL_ENV+x} && $# -lt 1 ]] && echo "No virtualenv specified or active." 1>&2 && return 1
+    ! __virtualenv_currently_active && [[ $# -lt 1 ]] && echo "No virtualenv specified or active." 1>&2 && return 1
     
     local env=${1:-${VIRTUAL_ENV_NAME}}
     
@@ -153,7 +153,7 @@ __virtualb_freeze () {
 
 
 __virtualb_pwd () {
-    [[ -z ${VIRTUAL_ENV+x} ]] && echo "No virtualenv is active." && return 0
+    ! __virtualenv_currently_active && echo "No virtualenv is active." && return 0
 
     echo $VIRTUAL_ENV
 }
@@ -165,7 +165,7 @@ __virtualb_mv () {
 
     [[ -z "$current_name" || -z "$new_name" ]] && echo "Must specify virtualenv to rename and the new name." 1>&2 && return 1
 
-    [[ ${VIRTUAL_ENV_NAME} == ${current_name} ]] && echo "Cannot rename virtualenv ${env_name} while it is in use." 1>&2 && return 1
+    [[ ${VIRTUAL_ENV_NAME} == ${current_name} ]] && echo "Cannot rename virtualenv ${current_name} while it is in use." 1>&2 && return 1
 
     if ! __virtualenv_exists ${current_name}; then
         echo "The virtualenv ${current_name} does not exist." 1>&2
@@ -182,10 +182,32 @@ __virtualb_rename () {
 }
 
 
-__virtualenv_exists () {
-    [[ -d "$VIRTUALB_HOME/$1" ]] || return 1
+__virtualb_exec () {
+    local exec_env exec_cmd env_python
+    # vb exec [env] [command]
+    if [[ $# -eq 2 ]]; then
+        exec_env=$1
+        exec_cmd=$2
+        ! __virtualenv_exists $exec_env && echo "virtualenv $exec_env does not exist." 1>&2 && return 1
+    elif  __virtualenv_currently_active && [[ $# -eq 1 ]]; then
+        exec_env=$VIRTUAL_ENV_NAME
+        exec_cmd=$1
+    elif ! __virtualenv_currently_active && [[ $# -lt 2 ]]; then
+        echo "No virtualenv specified or active" 1>&2
+        return 1
+    fi
+
+    eval "$VIRTUALB_HOME/$exec_env/bin/python ${exec_cmd}"
+
 }
 
+__virtualenv_exists () {
+    [[ -d "$VIRTUALB_HOME/$1" ]]
+}
+
+__virtualenv_currently_active() {
+    [[ -n ${VIRTUAL_ENV+x} ]]
+}
 
 __install_deps () {
     local install
@@ -205,7 +227,7 @@ __confirm_remove () {
 
 
 __vb_completions() {
-    [[ $1 == "activate" || $1 == "rm" || $1 == "freeze" || $1 == "mv" || $1 == "rename" ]] && __virtualb_ls
+    [[ $1 == "activate" || $1 == "rm" || $1 == "freeze" || $1 == "mv" || $1 == "rename" || $1 == "exec" ]] && __virtualb_ls
     [[ $1 == "help" ]] && __vb_all_cmds
 }
 
@@ -229,9 +251,8 @@ _vb () {
         COMPREPLY=( $(compgen -W "$cmds" -- "$word") )
 
     else
-        local words=("${COMP_WORDS[@]}")
-        unset words[0]
-        unset words[$COMP_CWORD]
+        # progressively shift the array to the left, removing all entered words except the most recent
+        local words=("${COMP_WORDS[@]:$(($COMP_CWORD - 1))}")
         local completions=$(__vb_completions "${words[@]}")
         COMPREPLY=( $(compgen -W "$completions" -- "$word") )
     fi


### PR DESCRIPTION
### Issue 3: `vb exec`
This PR implements the `vb exec` command, which allows the user to pass arguments / commands to an arbitrary virtualenv. I made some minor changes; I'll detail those here too.

I'm still open to changing the command name, if we want to land on a different one (`remote` still stands out).

### What should the reviewer look for?

- README.md:
    - Added a "quick install" section close to the top
    - Added section in table for new command
- docs/cmd_exec:
    - New doc file for exec command
- virtualb.plugin.bash:
    - Change "subcommand" to "command" to keep consistent wording
    - Replaced all instances of `[[ -z ${VIRTUAL_ENV+x} ]]` with the truthy `__virtualenv_currently_active` to make checking easier
    - Added `__virtualb_exec` function to handle new `exec` command
    - Clean up `__vb_completions` function to use an array for command identity
    - Clean up `_vb` (completer) function to progressively send the last command the user typed & allowing richer autocomplete functionality

### How can the reviewer test this?

`git pull` and source the new plugin file, then try out:

```bash
echo '{"hello":"world"}' | vb exec -e my_env -c "import sys, json; j = json.load(sys.stdin); print(j['hello']); print(sys.path)"
```
with multiple env's activated, and with & without the -e argument to confirm that the argument overrides the currently activated env, but that it defaults to the active one without it specified.
with different 